### PR TITLE
Render sketch in a centered square by default

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,14 +8,17 @@
   </script>
   <style>
     body {
+      display: grid;
       position: fixed;
       top: 0;
       left: 0;
       z-index: -1;
       width: 100vw;
       height: 100vh;
+      max-height: -webkit-fill-available;
       padding: 0;
       margin: 0;
+      place-items: center;
     }
   </style>
 </head>

--- a/index.js
+++ b/index.js
@@ -1,8 +1,9 @@
 // example
 const canvas = document.createElement("canvas");
 canvas.id = "myCanvas";
-canvas.width = window.innerWidth;
-canvas.height = window.innerHeight;
+// Use innerWidth and innerHeight if you want the screen format rather than a square. 
+canvas.width = Math.min(window.innerWidth, window.innerHeight);
+canvas.height = Math.min(window.innerWidth, window.innerHeight);
 canvas.style.zIndex = 8;
 canvas.style.position = "absolute";
 
@@ -13,8 +14,8 @@ const ctx = canvas.getContext("2d");
 
 function drawArt() {
     // example
-    const width = window.innerWidth;
-    const height = window.innerHeight;
+    const width = Math.min(window.innerWidth, window.innerHeight);
+    const height = Math.min(window.innerWidth, window.innerHeight);
     canvas.width = width;
     canvas.height = height;
     ctx.clearRect(0, 0, width, height);


### PR DESCRIPTION
Hi Piero,

I noticed that most artists who use Editart choose to keep the square format for live mode (probably so that the composition in preview mode and live mode is consistent).

I thought it would be good to have this as the default behavior in your template, as well as CSS rules to center the canvas on the page (they don't affect full-page rendering).

I'll leave it up to you to decide whether these changes are worth making to the template; perhaps they aren't necessary.